### PR TITLE
Add `BadRequestFlag` to `Violation`

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -46,7 +46,7 @@ func (v *Validator) RequestValidate(r *http.Request) (bool, []*Violation, interf
 	vcx := newValidatorContext(r)
 	var obj interface{} = nil
 	if r.Body == nil {
-		vcx.AddViolation(NewEmptyViolation(MessageRequestBodyEmpty))
+		vcx.AddViolation(NewBadRequestViolation(MessageRequestBodyEmpty))
 	} else {
 		decoder := json.NewDecoder(r.Body)
 		if v.UseNumber {
@@ -55,10 +55,10 @@ func (v *Validator) RequestValidate(r *http.Request) (bool, []*Violation, interf
 		obj = reflect.Interface
 		if err := decoder.Decode(&obj); err != nil {
 			obj = nil
-			vcx.AddViolation(NewEmptyViolation(MessageUnableToDecode))
+			vcx.AddViolation(NewBadRequestViolation(MessageUnableToDecode))
 		} else if obj == nil {
 			if !v.AllowNull {
-				vcx.AddViolation(NewEmptyViolation(MessageRequestBodyNotJsonNull))
+				vcx.AddViolation(NewBadRequestViolation(MessageRequestBodyNotJsonNull))
 			}
 		} else {
 			// determine whether body is a map (object) or an array...
@@ -79,7 +79,7 @@ func (v *Validator) RequestValidate(r *http.Request) (bool, []*Violation, interf
 					v.validate(m, vcx)
 				}
 			} else {
-				vcx.AddViolation(NewEmptyViolation(MessageRequestBodyExpectedJsonObject))
+				vcx.AddViolation(NewBadRequestViolation(MessageRequestBodyExpectedJsonObject))
 			}
 		}
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -136,6 +136,8 @@ func TestRequestValidation(t *testing.T) {
 	ok, violations, obj := personValidator.RequestValidate(req)
 	require.False(t, ok)
 	require.Equal(t, 2, len(violations))
+	require.False(t, violations[0].BadRequest)
+	require.False(t, violations[1].BadRequest)
 	require.NotNil(t, obj)
 }
 
@@ -161,6 +163,8 @@ func TestRequestValidationUsingJsonNumber(t *testing.T) {
 	ok, violations, obj := validator.RequestValidate(req)
 	require.False(t, ok)
 	require.Equal(t, 2, len(violations))
+	require.False(t, violations[0].BadRequest)
+	require.False(t, violations[1].BadRequest)
 	require.NotNil(t, obj)
 }
 
@@ -173,6 +177,8 @@ func TestRequestValidationWithArray(t *testing.T) {
 	ok, violations, obj := personValidator.RequestValidate(req)
 	require.False(t, ok)
 	require.Equal(t, 2, len(violations))
+	require.False(t, violations[0].BadRequest)
+	require.False(t, violations[1].BadRequest)
 	require.NotNil(t, obj)
 }
 
@@ -186,6 +192,7 @@ func TestRequestValidationWithJsonNullBody(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, 1, len(violations))
 	require.Equal(t, MessageRequestBodyNotJsonNull, violations[0].Message)
+	require.True(t, violations[0].BadRequest)
 	require.Nil(t, obj)
 }
 
@@ -198,6 +205,7 @@ func TestRequestValidationWithNoBody(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, 1, len(violations))
 	require.Equal(t, MessageRequestBodyEmpty, violations[0].Message)
+	require.True(t, violations[0].BadRequest)
 	require.Nil(t, obj)
 }
 
@@ -212,6 +220,7 @@ func TestRequestValidationFailsWithArrayWhenArrayNotAllowed(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, 1, len(violations))
 	require.Equal(t, MessageRequestBodyNotJsonArray, violations[0].Message)
+	require.False(t, violations[0].BadRequest)
 	require.NotNil(t, obj)
 }
 
@@ -226,6 +235,7 @@ func TestRequestValidationFailsWithObjectWhenObjectNotAllowed(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, 1, len(violations))
 	require.Equal(t, MessageRequestBodyExpectedJsonArray, violations[0].Message)
+	require.False(t, violations[0].BadRequest)
 	require.NotNil(t, obj)
 }
 
@@ -240,6 +250,7 @@ func TestRequestValidationFailsWhenExpectingObject(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, 1, len(violations))
 	require.Equal(t, MessageRequestBodyExpectedJsonObject, violations[0].Message)
+	require.True(t, violations[0].BadRequest)
 	require.NotNil(t, obj)
 }
 
@@ -254,6 +265,7 @@ func TestRequestValidationFailsWhenObjectDisallowed(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, 1, len(violations))
 	require.Equal(t, MessageRequestBodyNotJsonObject, violations[0].Message)
+	require.False(t, violations[0].BadRequest)
 	require.NotNil(t, obj)
 }
 
@@ -267,6 +279,7 @@ func TestRequestValidationWithBadJson(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, 1, len(violations))
 	require.Equal(t, MessageUnableToDecode, violations[0].Message)
+	require.True(t, violations[0].BadRequest)
 	require.Nil(t, obj)
 }
 

--- a/violation.go
+++ b/violation.go
@@ -8,6 +8,19 @@ type Violation struct {
 	Path string
 	// Message is the violation message
 	Message string
+	// BadRequest is a flag indicating that the request could not be validated because
+	// the payload was not JSON.  This effectively allows the caller of validation to determine
+	// whether to respond with `400 Bad Request` or `422 Unprocessable Entity`
+	//
+	// Such violations are only added by the Validator.RequestValidate method where:
+	//
+	// * the request has an empty body
+	//
+	// * the request body does not parse (unmarshal) as JSON
+	//
+	// * the request body is JSON null (i.e. a request body containing just 'null') and the
+	// Validator.AllowNull is set to false
+	BadRequest bool
 }
 
 // NewViolation creates a new violation with the specified property, path and message
@@ -25,5 +38,14 @@ func NewEmptyViolation(msg string) *Violation {
 		Property: "",
 		Path:     "",
 		Message:  msg,
+	}
+}
+
+func NewBadRequestViolation(msg string) *Violation {
+	return &Violation{
+		Property:   "",
+		Path:       "",
+		Message:    msg,
+		BadRequest: true,
 	}
 }


### PR DESCRIPTION
This effectively allows the caller of validation to determine whether to respond with `400 Bad Request` or `422 Unprocessable Entity`