### PR TITLE
Add `StopOnFirst`

### DIFF
--- a/common_constraints.go
+++ b/common_constraints.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"golang.org/x/text/unicode/norm"
+	"net/mail"
 	"regexp"
 	"strings"
 	"time"
@@ -43,6 +44,7 @@ const (
 	messageUuidCorrectVer           = "Value must be a valid UUID (version %d)"
 	uuidRegexpPattern               = "^([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})$"
 	messageValidCardNumber          = "Value must be a valid card number"
+	messageValidEmail               = "Value must be an email address"
 )
 
 var (
@@ -1035,6 +1037,32 @@ func stringToTime(str string) (*time.Time, bool) {
 	}
 	result, err := time.Parse(parseLayout, str)
 	return &result, err == nil
+}
+
+// StringValidEmail constraint checks that a string contains a valid email address (does not
+// verify the email address!)
+//
+// NB. Uses mail.ParseAddress to check valid email address
+type StringValidEmail struct {
+	// the violation message to be used if the constraint fails (see Violation.Message)
+	//
+	// (if the Message is an empty string then the default violation message is used)
+	Message string
+}
+
+// Check implements Constraint.Check
+func (c *StringValidEmail) Check(v interface{}, vcx *ValidatorContext) (bool, string) {
+	if str, ok := v.(string); ok {
+		if _, err := mail.ParseAddress(str); err != nil {
+			return false, c.GetMessage()
+		}
+	}
+	return true, ""
+}
+
+// GetMessage implements the Constraint.GetMessage
+func (c *StringValidEmail) GetMessage() string {
+	return defaultMessage(c.Message, messageValidEmail)
 }
 
 func defaultMessage(msg string, def string) string {

--- a/common_constraints_test.go
+++ b/common_constraints_test.go
@@ -1300,6 +1300,28 @@ func TestStringValidCardNumberConstraint(t *testing.T) {
 	}
 }
 
+func TestStringValidEmail(t *testing.T) {
+	validator := buildFooValidator(JsonAny,
+		&StringValidEmail{}, false)
+	obj := map[string]interface{}{
+		"foo": "",
+	}
+	testEmailAddrs := map[string]bool{
+		"":                          false,
+		"123":                       false,
+		"me@example.com":            true,
+		"Bilbo <bilbo@example.com>": true,
+		"me@coffee":                 true,
+	}
+	for ea, expect := range testEmailAddrs {
+		t.Run(fmt.Sprintf("Email:\"%s\"", ea), func(t *testing.T) {
+			obj["foo"] = ea
+			ok, _ := validator.Validate(obj)
+			require.Equal(t, expect, ok)
+		})
+	}
+}
+
 func buildFooValidator(propertyType JsonType, constraint Constraint, notNull bool) *Validator {
 	return &Validator{
 		Properties: Properties{

--- a/context.go
+++ b/context.go
@@ -9,6 +9,8 @@ import (
 type ValidatorContext struct {
 	// ok is the final result of the validator
 	ok bool
+	// stopOnFirst is whether the validator has been set to stop on first violation
+	stopOnFirst bool
 	// continueAll is whether entire validation is ok to continue
 	continueAll bool
 	// root is the original starting object (map or slice) for the validator
@@ -19,9 +21,10 @@ type ValidatorContext struct {
 	pathStack []*pathStackItem
 }
 
-func newValidatorContext(root interface{}) *ValidatorContext {
+func newValidatorContext(root interface{}, stopOnFirst bool) *ValidatorContext {
 	return &ValidatorContext{
 		ok:          true,
+		stopOnFirst: stopOnFirst,
 		continueAll: true,
 		root:        root,
 		violations:  []*Violation{},
@@ -41,6 +44,9 @@ func newValidatorContext(root interface{}) *ValidatorContext {
 func (vc *ValidatorContext) AddViolation(v *Violation) {
 	vc.violations = append(vc.violations, v)
 	vc.ok = false
+	if vc.stopOnFirst {
+		vc.continueAll = false
+	}
 }
 
 // AddViolationForCurrent adds a Violation to the validation context for

--- a/context_test.go
+++ b/context_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCreateContext(t *testing.T) {
-	vcx := newValidatorContext(nil)
+	vcx := newValidatorContext(nil, false)
 	require.Nil(t, vcx.CurrentProperty())
 	require.Nil(t, vcx.CurrentPropertyName())
 	require.Nil(t, vcx.CurrentArrayIndex())
@@ -14,7 +14,7 @@ func TestCreateContext(t *testing.T) {
 }
 
 func TestContextPathing(t *testing.T) {
-	vcx := newValidatorContext(nil)
+	vcx := newValidatorContext(nil, false)
 	require.Nil(t, vcx.CurrentProperty())
 	require.Equal(t, "", vcx.CurrentPath())
 
@@ -50,7 +50,7 @@ func TestContextPathing(t *testing.T) {
 }
 
 func TestContextIndexPathing(t *testing.T) {
-	vcx := newValidatorContext(nil)
+	vcx := newValidatorContext(nil, false)
 	require.Nil(t, vcx.CurrentProperty())
 	require.Nil(t, vcx.CurrentPropertyName())
 	require.Nil(t, vcx.CurrentArrayIndex())
@@ -93,7 +93,7 @@ func TestContextIndexPathing(t *testing.T) {
 }
 
 func TestContextIndexPathingFromRoot(t *testing.T) {
-	vcx := newValidatorContext(nil)
+	vcx := newValidatorContext(nil, false)
 	require.Nil(t, vcx.CurrentProperty())
 	require.Nil(t, vcx.CurrentPropertyName())
 	require.Nil(t, vcx.CurrentArrayIndex())
@@ -117,7 +117,7 @@ func TestContextIndexPathingFromRoot(t *testing.T) {
 	require.Nil(t, vcx.CurrentArrayIndex())
 	require.Equal(t, "[0].foo", vcx.CurrentPath())
 
-	vcx = newValidatorContext(nil)
+	vcx = newValidatorContext(nil, false)
 	require.Nil(t, vcx.CurrentProperty())
 	require.Nil(t, vcx.CurrentPropertyName())
 	require.Nil(t, vcx.CurrentArrayIndex())
@@ -131,7 +131,7 @@ func TestContextIndexPathingFromRoot(t *testing.T) {
 }
 
 func TestPathPopNeverFails(t *testing.T) {
-	vcx := newValidatorContext(nil)
+	vcx := newValidatorContext(nil, false)
 
 	// push 4...
 	vcx.pushPathProperty("foo1", nil)
@@ -177,7 +177,7 @@ func TestPathPopNeverFails(t *testing.T) {
 }
 
 func TestContext_CurrentDepth(t *testing.T) {
-	vcx := newValidatorContext(nil)
+	vcx := newValidatorContext(nil, false)
 	require.Equal(t, 0, vcx.CurrentDepth())
 
 	vcx.pushPathProperty("foo", nil)
@@ -198,7 +198,7 @@ func TestContext_CurrentDepth(t *testing.T) {
 }
 
 func TestContext_AncestorPath(t *testing.T) {
-	vcx := newValidatorContext(nil)
+	vcx := newValidatorContext(nil, false)
 	ap, apok := vcx.AncestorPath(0)
 	require.False(t, apok)
 	require.Nil(t, ap)
@@ -229,7 +229,7 @@ func TestContext_AncestorPath(t *testing.T) {
 }
 
 func TestContext_AncestorProperty(t *testing.T) {
-	vcx := newValidatorContext(nil)
+	vcx := newValidatorContext(nil, false)
 	ap, apok := vcx.AncestorProperty(0)
 	require.False(t, apok)
 	require.Nil(t, ap)
@@ -276,7 +276,7 @@ func TestContext_AncestorProperty(t *testing.T) {
 }
 
 func TestContext_AncestorPropertyName(t *testing.T) {
-	vcx := newValidatorContext(nil)
+	vcx := newValidatorContext(nil, false)
 	vcx.pushPathProperty("foo", nil)
 	vcx.pushPathProperty("bar", nil)
 	vcx.pushPathProperty("baz", nil)
@@ -304,7 +304,7 @@ func TestContext_AncestorPropertyName(t *testing.T) {
 }
 
 func TestContext_AncestorArrayIndex(t *testing.T) {
-	vcx := newValidatorContext(nil)
+	vcx := newValidatorContext(nil, false)
 	vcx.pushPathIndex(0, nil)
 	vcx.pushPathIndex(1, nil)
 	vcx.pushPathIndex(2, nil)

--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,15 @@
 
 Check requests in the form of *http.Request, `map[string]interface{}` or `[]interface{}`
 
-Validators can be expressed effectively as, for example:
+Validators can be created from existing structs, for example:
+	type AddPersonRequest struct {
+		Name string `json:"name" v8n:"notNull,mandatory,&StringNoControlCharacters{},&StringLength{Minimum: 1, Maximum: 255}"`
+		Age int `json:"age" v8n:"type:Integer,notNull,mandatory,&PositiveOrZero{}"`
+	}
+	var AddPersonRequestValidator = valix.MustCompileValidatorFor(AddPersonRequest{}, nil)
+
+
+Or validators can be expressed effectively in code, for example:
 	var personValidator = &valix.Validator{
 		IgnoreUnknownProperties: false,
 		Properties: valix.Properties{

--- a/property_validator.go
+++ b/property_validator.go
@@ -118,6 +118,8 @@ type PropertyValidator struct {
 	Constraints Constraints
 	// ObjectValidator is checked, if specified, after all Constraints are checked
 	ObjectValidator *Validator
+	// Order is the order in which the property is checked (see Validator.OrderedPropertyChecks)
+	Order int
 }
 
 func (pv *PropertyValidator) validate(actualValue interface{}, vcx *ValidatorContext) {

--- a/tag_parsing_test.go
+++ b/tag_parsing_test.go
@@ -26,8 +26,6 @@ func TestParseCommasWithBadTags(t *testing.T) {
 
 func TestParseV8nTagSimple(t *testing.T) {
 	tagStr := "type:string,notNull,mandatory,constraints:[StringNotEmpty{Message: \"''''Foo\"}]"
-	//         01234567890123456789012345678901234567890123456789012345678901234567890123
-	//                   1         2         3         4         5         6         7
 	list, err := parseCommas(tagStr)
 	require.Nil(t, err)
 	require.Equal(t, 4, len(list))
@@ -161,6 +159,15 @@ func TestPropertyValidator_AddTagItemConstraint(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, fmt.Sprintf(msgUnknownConstraint, "UNKNOWN"), err.Error())
 	require.Equal(t, 2, len(pv.Constraints))
+
+	err = pv.addTagItem("&StringValidToken{Tokens:['XXX',\"YYY\",'ZZZ']}")
+	require.Nil(t, err)
+	require.Equal(t, 3, len(pv.Constraints))
+	c := pv.Constraints[2].(*StringValidToken)
+	require.Equal(t, 3, len(c.Tokens))
+	require.Equal(t, "XXX", c.Tokens[0])
+	require.Equal(t, "YYY", c.Tokens[1])
+	require.Equal(t, "ZZZ", c.Tokens[2])
 }
 
 func TestPropertyValidator_AddObjectTagItem_IgnoreUnknownProperties(t *testing.T) {

--- a/validator_for.go
+++ b/validator_for.go
@@ -12,10 +12,32 @@ const (
 )
 
 type ValidatorForOptions struct {
+	// IgnoreUnknownProperties is whether to ignore unknown properties (default false)
+	//
+	// Set this to `true` if you want to allow unknown properties
 	IgnoreUnknownProperties bool
-	Constraints             Constraints
-	AllowNullJson           bool
-	UseNumber               bool
+	// Constraints is an optional slice of Constraint items to be checked on the object/array
+	//
+	// * These are checked in the order specified and prior to property validator & unknown property checks
+	Constraints Constraints
+	// AllowNullJson forces validator to accept a request body that is null JSON (i.e. a body containing just `null`)
+	AllowNullJson bool
+	// AllowArray denotes, when true (default is false), that this validator will allow a JSON array - where each
+	// item in the array can be validated as an object
+	AllowArray bool
+	// DisallowObject denotes, when set to true, that this validator will disallow JSON objects - i.e. that it
+	// expects JSON arrays (in which case the AllowArray should also be set to true)
+	DisallowObject bool
+	// StopOnFirst if set, instructs the validator to stop at the first violation found
+	StopOnFirst bool
+	// UseNumber forces RequestValidate method to use json.Number when decoding request body
+	UseNumber bool
+	// OrderedPropertyChecks determines whether properties should be checked in order - when set to true, properties
+	// are sorted by PropertyValidator.Order and property name
+	//
+	// When this is set to false (default) properties are checked in the order in which they appear in the properties map -
+	// which is unpredictable
+	OrderedPropertyChecks bool
 }
 
 const (
@@ -67,12 +89,17 @@ func emptyValidatorFromOptions(options *ValidatorForOptions) *Validator {
 		DisallowObject:          false,
 		AllowNullJson:           false,
 		UseNumber:               false,
+		StopOnFirst:             false,
 	}
 	if options != nil {
 		result.IgnoreUnknownProperties = options.IgnoreUnknownProperties
 		result.Constraints = options.Constraints
 		result.AllowNullJson = options.AllowNullJson
 		result.UseNumber = options.UseNumber
+		result.AllowArray = options.AllowArray
+		result.DisallowObject = options.DisallowObject
+		result.StopOnFirst = options.StopOnFirst
+		result.OrderedPropertyChecks = options.OrderedPropertyChecks
 	}
 	return result
 }


### PR DESCRIPTION
Stops validation on encountering first violation
Also:
* Optional control over property validation order
* Added `StringValidEmail` constraint
* More documentation improvements
* Fix `Validator.ValidateReaderInto` (incorrect error messages)
* More `ValidatorForOptions` options (`AllowArray`, `DisallowObject`, `StopOnFirst` & `OrderedPropertyChecks`)