### PR TITLE
Improve SetCondition constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2290,7 +2290,7 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
             <code>SetConditionFrom</code><br>&nbsp;&nbsp;<code>cfrom</code>&nbsp;<em>(i18n tag abbr.)</em>
         </td>
         <td>
-            Is a utility constraint that can be used to set a condition in the <code>ValidatorContext</code> from string value of
+            Is a utility constraint that can be used to set a condition in the <code>ValidatorContext</code> from the value of
             the property to which this constraint is added.<br/>
             <em>(see example usage in <a href="#conditional-constraints">Conditional Constraints</a>)</em>
             <details>
@@ -2317,7 +2317,7 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>Prefix</code> <em>string</em>
                         </td>
                         <td>
-                            is any prefix to be appended to the string value
+                            is any prefix to be appended to the condition token
                         </td>
                     </tr>
                     <tr>
@@ -2326,6 +2326,23 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                         </td>
                         <td>
                             converts the string value to alternate values (if the value is not found in the map then the original value is used
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>NullToken</code> <em>string</em>
+                        </td>
+                        <td>
+                            is the condition token used if the value of the property is null/nil.  If this field is not set
+                            and the property value is null at validation - then a condition token of "null" is used
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>Format</code> <em>string</em>
+                        </td>
+                        <td>
+                            is an optional format string for dealing with non-string property values
                         </td>
                     </tr>
                 </table>
@@ -2350,8 +2367,8 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
             <code>SetConditionProperty</code><br>&nbsp;&nbsp;<code>cpty</code>&nbsp;<em>(i18n tag abbr.)</em>
         </td>
         <td>
-            Is a utility constraint that can be used to set a condition in the <code>ValidatorContext</code> from string value of a
-            specified property.<br/>
+            Is a utility constraint that can be used to set a condition in the <code>ValidatorContext</code> from the value of a specified property 
+            within the object to which this constraint is attached<br/>
             <em>(see example usage in <a href="#polymorphic-validation">Polymorphic Validation</a>)</em>
             <details>
                 <summary>Fields</summary>
@@ -2369,7 +2386,7 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>Prefix</code> <em>string</em>
                         </td>
                         <td>
-                            is any prefix to be appended to the string value
+                            is any prefix to be appended to the condition token
                         </td>
                     </tr>
                     <tr>
@@ -2377,7 +2394,33 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>Mapping</code> <em>map[string]string</em>
                         </td>
                         <td>
-                            converts the string value to alternate values (if the value is not found in the map then the original value is used
+                            converts the token value to alternate values (if the value is not found in the map then the original value is used
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>NullToken</code> <em>string</em>
+                        </td>
+                        <td>
+                            is the condition token used if the value of the property specified is null/nil.  If this field is not set
+                            and the property value is null at validation - then a condition token of "null" is used
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>MissingToken</code> <em>string</em>
+                        </td>
+                        <td>
+                            is the condition token used if the property specified is missing.  If this field is not set
+                            and the property is missing at validation - then a condition token of "missing" is used
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <code>Format</code> <em>string</em>
+                        </td>
+                        <td>
+                            is an optional format string for dealing with non-string property values
                         </td>
                     </tr>
                 </table>

--- a/constraints_special.go
+++ b/constraints_special.go
@@ -2,6 +2,7 @@ package valix
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 )
 
@@ -63,7 +64,7 @@ func (c *FailWhen) GetMessage(tcx I18nContext) string {
 }
 
 // SetConditionFrom constraint is a utility constraint that can be used to set a condition in the
-// ValidatorContext from string value of the property (to which this constraint is added)
+// ValidatorContext from the value of the property (to which this constraint is added)
 //
 // Note: It will only set a condition if the property value is a string!
 type SetConditionFrom struct {
@@ -73,26 +74,37 @@ type SetConditionFrom struct {
 	// Global setting this field to true means the condition is set for the entire
 	// validator context
 	Global bool
-	// Prefix is any prefix to be appended to the string value
+	// Prefix is any prefix to be appended to the condition token
 	Prefix string
 	// Mapping converts the string value to alternate values (if the value is not found in the map
 	// then the original value is used
 	Mapping map[string]string
+	// NullToken is the condition token used if the value of the property is null/nil.  If this field is not set
+	// and the property value is null at validation - then a condition token of "null" is used
+	NullToken string
+	// Format is an optional format string for dealing with non-string property values
+	Format string
 }
 
 // Check implements Constraint.Check
 func (c *SetConditionFrom) Check(v interface{}, vcx *ValidatorContext) (bool, string) {
-	if str, ok := v.(string); ok {
-		if alt, aOk := c.Mapping[str]; aOk {
-			str = alt
-		}
-		if c.Global {
-			vcx.SetGlobalCondition(c.Prefix + str)
-		} else if c.Parent {
-			vcx.SetParentCondition(c.Prefix + str)
+	useToken := defaultString(c.NullToken, "null")
+	if v != nil {
+		if str, ok := v.(string); ok {
+			useToken = str
 		} else {
-			vcx.SetCondition(c.Prefix + str)
+			useToken = fmt.Sprintf(defaultString(c.Format, "%v"), v)
 		}
+	}
+	if alt, ok := c.Mapping[useToken]; ok {
+		useToken = alt
+	}
+	if c.Global {
+		vcx.SetGlobalCondition(c.Prefix + useToken)
+	} else if c.Parent {
+		vcx.SetParentCondition(c.Prefix + useToken)
+	} else {
+		vcx.SetCondition(c.Prefix + useToken)
 	}
 	return true, c.GetMessage(vcx)
 }
@@ -172,33 +184,47 @@ func (c *SetConditionOnType) GetMessage(tcx I18nContext) string {
 }
 
 // SetConditionProperty constraint is a utility constraint that can be used to set a condition in the
-// ValidatorContext from string value of a specified property within the object to which this
+// ValidatorContext from the value of a specified property within the object to which this
 // constraint is attached
 //
 // This constraint is normally only used in Validator.Constraints
 //
-// Note: It will only set a condition if the specified property value is a string!
+// Note: The property value can be of any type (inc. null) or, indeed, the property may be missing
 type SetConditionProperty struct {
 	// PropertyName is the name of the property to extract the condition value from
 	PropertyName string `v8n:"default"`
-	// Prefix is any prefix to be appended to the string value
+	// Prefix is any prefix to be appended to the condition token
 	Prefix string
-	// Mapping converts the string value to alternate values (if the value is not found in the map
-	// then the original value is used
+	// Mapping converts the token value to alternate values (if the value is not found in the map
+	// then the original value is used)
 	Mapping map[string]string
+	// NullToken is the condition token used if the value of the property specified is null/nil.  If this field is not set
+	// and the property value is null at validation - then a condition token of "null" is used
+	NullToken string
+	// MissingToken is the condition token used if the property specified is missing.  If this field is not set
+	// and the property is missing at validation - then a condition token of "missing" is used
+	MissingToken string
+	// Format is an optional format string for dealing with non-string property values
+	Format string
 }
 
 // Check implements Constraint.Check
 func (c *SetConditionProperty) Check(v interface{}, vcx *ValidatorContext) (bool, string) {
 	if m, ok := v.(map[string]interface{}); ok {
+		useToken := defaultString(c.MissingToken, "missing")
 		if raw, ok := m[c.PropertyName]; ok {
-			if str, ok := raw.(string); ok {
-				if alt, aOk := c.Mapping[str]; aOk {
-					str = alt
-				}
-				vcx.SetCondition(c.Prefix + str)
+			if raw == nil {
+				useToken = defaultString(c.NullToken, "null")
+			} else if str, ok := raw.(string); ok {
+				useToken = str
+			} else {
+				useToken = fmt.Sprintf(defaultString(c.Format, "%v"), raw)
 			}
 		}
+		if alt, ok := c.Mapping[useToken]; ok {
+			useToken = alt
+		}
+		vcx.SetCondition(c.Prefix + useToken)
 	}
 	return true, c.GetMessage(vcx)
 }

--- a/utils.go
+++ b/utils.go
@@ -76,6 +76,13 @@ func coerceToInt(value interface{}) (i int64, ok bool, isNumber bool) {
 	return
 }
 
+func defaultString(str string, def string) string {
+	if str != "" {
+		return str
+	}
+	return def
+}
+
 // ternary operations
 
 type ternary bool


### PR DESCRIPTION
'SetConditionFrom' and `SetConditionProperty` special constraints can now deal with non-string and null values.
`SetConditionProperty` can now also deal with the property being missing