### PR TITLE
Expose presets

### DIFF
--- a/constraints_common.go
+++ b/constraints_common.go
@@ -196,9 +196,9 @@ type StringPresetPattern struct {
 func (c *StringPresetPattern) Check(v interface{}, vcx *ValidatorContext) (bool, string) {
 	if str, ok := v.(string); ok {
 		if p, ok := presetsRegistry.get(c.Preset); ok {
-			if !p.check(str) {
+			if !p.Check(str) {
 				vcx.CeaseFurtherIf(c.Stop)
-				return false, c.getMessage(vcx, p.msg)
+				return false, c.getMessage(vcx, p.GetMessage())
 			}
 		} else {
 			vcx.CeaseFurtherIf(c.Stop)
@@ -222,8 +222,10 @@ func (c *StringPresetPattern) getMessage(tcx I18nContext, msg string) string {
 func (c *StringPresetPattern) GetMessage(tcx I18nContext) string {
 	if c.Message != "" {
 		return obtainI18nContext(tcx).TranslateMessage(c.Message)
-	} else if p, ok := presetsRegistry.get(c.Preset); ok && p.msg != "" {
-		return obtainI18nContext(tcx).TranslateMessage(p.msg)
+	} else if p, ok := presetsRegistry.get(c.Preset); ok {
+		if msg := p.GetMessage(); msg != "" {
+			return obtainI18nContext(tcx).TranslateMessage(msg)
+		}
 	}
 	return obtainI18nContext(tcx).TranslateMessage(msgValidPattern)
 }

--- a/constraints_common_test.go
+++ b/constraints_common_test.go
@@ -188,7 +188,7 @@ func TestStringPresetPattern(t *testing.T) {
 
 	// defaulted message when preset has no message...
 	constraint.Message = ""
-	presetsRegistry.register("fooey", patternPreset{regex: regexp.MustCompile("zzz")})
+	presetsRegistry.register("fooey", &patternPreset{regex: regexp.MustCompile("zzz")})
 	defer func() {
 		presetsRegistry.reset()
 	}()

--- a/constraints_registry.go
+++ b/constraints_registry.go
@@ -273,6 +273,11 @@ func (r *constraintRegistry) has(name string) bool {
 	return ok
 }
 
+// GetRegisteredConstraint returns a previously registered constraint
+func GetRegisteredConstraint(name string) (Constraint, bool) {
+	return constraintsRegistry.get(name)
+}
+
 // RegisterConstraint registers a Constraint for use by ValidatorFor
 //
 // For example:

--- a/marshaling_test.go
+++ b/marshaling_test.go
@@ -115,8 +115,8 @@ func TestValidator_MarshalJSON(t *testing.T) {
 	err = json.Unmarshal(b, &obj)
 	require.Nil(t, err)
 	require.NotNil(t, obj)
-	pretty, _ := json.MarshalIndent(obj, "", "\t")
-	println(string(pretty[:]))
+	//pretty, _ := json.MarshalIndent(obj, "", "\t")
+	//println(string(pretty[:]))
 
 	valid, violations := ValidatorValidator.Validate(obj)
 	require.Equal(t, 0, len(violations))


### PR DESCRIPTION
Built-in presets now implement a public interface `Preset` - so that custom presets can wrap their behaviour (e.g. checking a card number but only accepting approved banks)