### PR TITLE
Allow dot notation on `PropertyName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -660,7 +663,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -752,7 +758,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -844,7 +853,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -1222,7 +1234,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -1316,7 +1331,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -1509,7 +1527,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -1546,7 +1567,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -1757,7 +1781,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -1794,7 +1821,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -3007,7 +3037,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -3737,7 +3770,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -3782,7 +3818,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -3917,7 +3956,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>
@@ -3962,7 +4004,10 @@ Valix provides a rich set of pre-defined common constraints - listed here for re
                             <code>PropertyName</code> <em>string</em>
                         </td>
                         <td>
-                            the property name of the other value to compare against
+                            the property name of the other value to compare against<br><br>
+                            Note: the <code>PropertyName</code> can also be JSON dot notation path - where leading dots allow traversal up
+                            the object tree and names, separated by dots, allow traversal down the object tree.<br>
+                            A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
                         </td>
                     </tr>
                     <tr>

--- a/constraints_compare.go
+++ b/constraints_compare.go
@@ -7,6 +7,10 @@ import (
 // EqualsOther constraint to check that a property value equals the value of another named property
 type EqualsOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// the violation message to be used if the constraint fails (see Violation.Message)
 	//
@@ -35,6 +39,10 @@ func (c *EqualsOther) GetMessage(tcx I18nContext) string {
 // NotEqualsOther constraint to check that a property value not equals the value of another named property
 type NotEqualsOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// the violation message to be used if the constraint fails (see Violation.Message)
 	//
@@ -182,6 +190,10 @@ func (c *LessThanOrEqual) GetMessage(tcx I18nContext) string {
 // constraint fails
 type GreaterThanOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// the violation message to be used if the constraint fails (see Violation.Message)
 	//
@@ -214,6 +226,10 @@ func (c *GreaterThanOther) GetMessage(tcx I18nContext) string {
 // constraint fails
 type GreaterThanOrEqualOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// the violation message to be used if the constraint fails (see Violation.Message)
 	//
@@ -245,6 +261,10 @@ func (c *GreaterThanOrEqualOther) GetMessage(tcx I18nContext) string {
 // constraint fails
 type LessThanOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// the violation message to be used if the constraint fails (see Violation.Message)
 	//
@@ -277,6 +297,10 @@ func (c *LessThanOther) GetMessage(tcx I18nContext) string {
 // constraint fails
 type LessThanOrEqualOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// the violation message to be used if the constraint fails (see Violation.Message)
 	//
@@ -427,6 +451,10 @@ func (c *StringLessThanOrEqual) GetMessage(tcx I18nContext) string {
 // Note: this constraint is strict - if either property value is not a string then this constraint fails
 type StringGreaterThanOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// when set, the comparison is case-insensitive
 	CaseInsensitive bool
@@ -459,6 +487,10 @@ func (c *StringGreaterThanOther) GetMessage(tcx I18nContext) string {
 // Note: this constraint is strict - if either property value is not a string then this constraint fails
 type StringGreaterThanOrEqualOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// when set, the comparison is case-insensitive
 	CaseInsensitive bool
@@ -491,6 +523,10 @@ func (c *StringGreaterThanOrEqualOther) GetMessage(tcx I18nContext) string {
 // Note: this constraint is strict - if either property value is not a string then this constraint fails
 type StringLessThanOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// when set, the comparison is case-insensitive
 	CaseInsensitive bool
@@ -523,6 +559,10 @@ func (c *StringLessThanOther) GetMessage(tcx I18nContext) string {
 // Note: this constraint is strict - if either property value is not a string then this constraint fails
 type StringLessThanOrEqualOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// when set, the comparison is case-insensitive
 	CaseInsensitive bool
@@ -696,6 +736,10 @@ func (c *DatetimeLessThanOrEqual) GetMessage(tcx I18nContext) string {
 // constraint fails
 type DatetimeGreaterThanOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// when set to true, excludes the time when comparing
 	//
@@ -731,6 +775,10 @@ func (c *DatetimeGreaterThanOther) GetMessage(tcx I18nContext) string {
 // constraint fails
 type DatetimeGreaterThanOrEqualOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// when set to true, excludes the time when comparing
 	//
@@ -766,6 +814,10 @@ func (c *DatetimeGreaterThanOrEqualOther) GetMessage(tcx I18nContext) string {
 // constraint fails
 type DatetimeLessThanOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// when set to true, excludes the time when comparing
 	//
@@ -801,6 +853,10 @@ func (c *DatetimeLessThanOther) GetMessage(tcx I18nContext) string {
 // constraint fails
 type DatetimeLessThanOrEqualOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// when set to true, excludes the time when comparing
 	//
@@ -1031,6 +1087,10 @@ const (
 // this constraint fails
 type DatetimeToleranceToOther struct {
 	// the property name of the other value to compare against
+	//
+	// Note: the PropertyName can also be JSON dot notation path - where leading dots allow traversal up
+	// the object tree and names, separated by dots, allow traversal down the object tree.
+	// A single dot at start is equivalent to no starting dot (i.e. a property name at the same level)
 	PropertyName string `v8n:"default"`
 	// the tolerance duration amount - which can be positive, negative or zero
 	//


### PR DESCRIPTION
Compare constraints to other property now allows dot notation - to compare against properties up and down the object tree.