### PR TITLE
Provider overrides

### DIFF
--- a/providers.go
+++ b/providers.go
@@ -1,0 +1,74 @@
+package valix
+
+import (
+	"encoding/json"
+	"io"
+	"reflect"
+	"strings"
+)
+
+// DefaultDecoderProvider is the decoder provider used by Validator - replace with your own if necessary
+var DefaultDecoderProvider DecoderProvider = &defaultDecoderProvider{}
+
+func getDefaultDecoderProvider() DecoderProvider {
+	if DefaultDecoderProvider != nil {
+		return DefaultDecoderProvider
+	}
+	return &defaultDecoderProvider{}
+}
+
+// DecoderProvider is the interface needed for replacing the DefaultDecoderProvider
+type DecoderProvider interface {
+	NewDecoder(r io.Reader, useNumber bool) *json.Decoder
+	NewDecoderFor(r io.Reader, validator *Validator) *json.Decoder
+}
+
+type defaultDecoderProvider struct{}
+
+func (ddp *defaultDecoderProvider) NewDecoder(r io.Reader, useNumber bool) *json.Decoder {
+	d := json.NewDecoder(r)
+	if useNumber {
+		d.UseNumber()
+	}
+	return d
+}
+
+func (ddp *defaultDecoderProvider) NewDecoderFor(r io.Reader, validator *Validator) *json.Decoder {
+	if validator == nil {
+		return ddp.NewDecoder(r, false)
+	}
+	d := ddp.NewDecoder(r, validator.UseNumber)
+	if !validator.IgnoreUnknownProperties {
+		d.DisallowUnknownFields()
+	}
+	return d
+}
+
+// DefaultPropertyNameProvider is the property name provider used by Validator - replace with your own if necessary
+var DefaultPropertyNameProvider PropertyNameProvider = &defaultPropertyNameProvider{}
+
+func getDefaultPropertyNameProvider() PropertyNameProvider {
+	if DefaultPropertyNameProvider != nil {
+		return DefaultPropertyNameProvider
+	}
+	return &defaultPropertyNameProvider{}
+}
+
+type PropertyNameProvider interface {
+	// NameFor provides the property name for a given struct field (return ok false if default field name is to be used)
+	NameFor(field reflect.StructField) (name string, ok bool)
+}
+
+type defaultPropertyNameProvider struct{}
+
+func (dpnp *defaultPropertyNameProvider) NameFor(field reflect.StructField) (name string, ok bool) {
+	result := field.Name
+	if tag, ok := field.Tag.Lookup(tagNameJson); ok {
+		if cAt := strings.Index(tag, ","); cAt != -1 {
+			result = tag[0:cAt]
+		} else {
+			result = tag
+		}
+	}
+	return result, true
+}

--- a/providers_test.go
+++ b/providers_test.go
@@ -1,0 +1,126 @@
+package valix
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDecoderProvider(t *testing.T) {
+	defer func() {
+		DefaultDecoderProvider = &defaultDecoderProvider{}
+	}()
+	jStr := `{
+		"foo": 1
+	}`
+
+	d := getDefaultDecoderProvider().NewDecoderFor(strings.NewReader(jStr), nil)
+	obj := map[string]interface{}{}
+	err := d.Decode(&obj)
+	require.Nil(t, err)
+	require.Equal(t, float64(1), obj["foo"])
+
+	d = getDefaultDecoderProvider().NewDecoder(strings.NewReader(jStr), true)
+	obj = map[string]interface{}{}
+	err = d.Decode(&obj)
+	require.Nil(t, err)
+	jn, ok := obj["foo"].(json.Number)
+	require.True(t, ok)
+	require.Equal(t, "1", jn.String())
+
+	v := &Validator{
+		UseNumber: false,
+	}
+	d = getDefaultDecoderProvider().NewDecoderFor(strings.NewReader(jStr), v)
+	obj = map[string]interface{}{}
+	err = d.Decode(&obj)
+	require.Nil(t, err)
+	require.Equal(t, float64(1), obj["foo"])
+
+	v.UseNumber = true
+	d = getDefaultDecoderProvider().NewDecoderFor(strings.NewReader(jStr), v)
+	obj = map[string]interface{}{}
+	err = d.Decode(&obj)
+	require.Nil(t, err)
+	jn, ok = obj["foo"].(json.Number)
+	require.True(t, ok)
+	require.Equal(t, "1", jn.String())
+
+	v.IgnoreUnknownProperties = false
+	d = getDefaultDecoderProvider().NewDecoderFor(strings.NewReader(jStr), v)
+	type unknownPtyTest struct {
+		Bar string
+	}
+	ts := &unknownPtyTest{}
+	err = d.Decode(ts)
+	require.NotNil(t, err)
+	require.Equal(t, "json: unknown field \"foo\"", err.Error())
+
+	v.IgnoreUnknownProperties = true
+	d = getDefaultDecoderProvider().NewDecoderFor(strings.NewReader(jStr), v)
+	ts = &unknownPtyTest{}
+	err = d.Decode(ts)
+	require.Nil(t, err)
+
+	// and nil replacement protection...
+	DefaultDecoderProvider = nil
+	d = getDefaultDecoderProvider().NewDecoderFor(strings.NewReader(jStr), v)
+	ts = &unknownPtyTest{}
+	err = d.Decode(ts)
+	require.Nil(t, err)
+}
+
+func TestDefaultPropertyNameProvider(t *testing.T) {
+	defer func() {
+		DefaultPropertyNameProvider = &defaultPropertyNameProvider{}
+	}()
+	type namesStruct struct {
+		Foo string `json:"foo,omitempty"`
+	}
+	ns := namesStruct{}
+	ty := reflect.TypeOf(ns)
+	fld := ty.Field(0)
+	name, ok := getDefaultPropertyNameProvider().NameFor(fld)
+	require.True(t, ok)
+	require.Equal(t, "foo", name)
+
+	type namesStruct2 struct {
+		Foo string
+	}
+	ns2 := namesStruct2{}
+	ty = reflect.TypeOf(ns2)
+	fld = ty.Field(0)
+	name, ok = getDefaultPropertyNameProvider().NameFor(fld)
+	require.True(t, ok)
+	require.Equal(t, "Foo", name)
+
+	// try replacement...
+	DefaultPropertyNameProvider = &testAutoLowerFirstLetter{}
+	name, ok = getDefaultPropertyNameProvider().NameFor(fld)
+	require.True(t, ok)
+	require.Equal(t, "foo", name)
+
+	// and nil replacement protection...
+	DefaultPropertyNameProvider = nil
+	name, ok = getDefaultPropertyNameProvider().NameFor(fld)
+	require.True(t, ok)
+	require.Equal(t, "Foo", name)
+}
+
+type testAutoLowerFirstLetter struct{}
+
+func (dpnp *testAutoLowerFirstLetter) NameFor(field reflect.StructField) (name string, ok bool) {
+	result := field.Name
+	if tag, ok := field.Tag.Lookup(tagNameJson); ok {
+		if cAt := strings.Index(tag, ","); cAt != -1 {
+			result = tag[0:cAt]
+		} else {
+			result = tag
+		}
+	} else {
+		result = strings.ToLower(result[:1]) + result[1:]
+	}
+	return result, true
+}

--- a/query_validate.go
+++ b/query_validate.go
@@ -48,10 +48,7 @@ func (v *Validator) RequestQueryValidateInto(req *http.Request, value interface{
 		// now read into the provided value...
 		buffer, _ := json.Marshal(obj)
 		intoReader := bytes.NewReader(buffer)
-		decoder := DefaultDecoderProvider.NewDecoder(intoReader, v.UseNumber)
-		if !v.IgnoreUnknownProperties {
-			decoder.DisallowUnknownFields()
-		}
+		decoder := getDefaultDecoderProvider().NewDecoderFor(intoReader, v)
 		err := decoder.Decode(value)
 		if err != nil {
 			vcx.AddViolation(newBadRequestViolation(vcx, msgErrorUnmarshall, CodeErrorUnmarshall, err))

--- a/validator_for.go
+++ b/validator_for.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 )
 
@@ -243,12 +242,8 @@ func initialPropertyValidator(fld reflect.StructField, name string) (*PropertyVa
 
 func getFieldName(fld reflect.StructField) string {
 	result := fld.Name
-	if tag, ok := fld.Tag.Lookup(tagNameJson); ok {
-		if cAt := strings.Index(tag, ","); cAt != -1 {
-			result = tag[0:cAt]
-		} else {
-			result = tag
-		}
+	if rn, ok := getDefaultPropertyNameProvider().NameFor(fld); ok {
+		result = rn
 	}
 	return result
 }


### PR DESCRIPTION
* Improved decoder overrides (added `NewDecoderFor` func on interface `DecoderProvider`)
* Added `DefaultPropertyNameProvider` - allows behaviour of struct fields to property name to be overridden
* Added default providers nil protection