### PR TITLE
Unicode normalisation form

### DIFF
--- a/constraint_utils.go
+++ b/constraint_utils.go
@@ -3,6 +3,7 @@ package valix
 import (
 	"encoding/json"
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/text/unicode/norm"
 	"math"
 	"regexp"
 	"strconv"
@@ -628,6 +629,23 @@ func checkStringConstraint(v interface{}, vcx *ValidatorContext, c stringConstra
 		return false, c.GetMessage(vcx)
 	}
 	return true, ""
+}
+
+func getUnicodeNormalisationForm(f string) (form norm.Form, ok bool) {
+	ok = true
+	switch strings.ToUpper(f) {
+	case "NFC":
+		form = norm.NFC
+	case "NFKC":
+		form = norm.NFKC
+	case "NFD":
+		form = norm.NFD
+	case "NFKD":
+		form = norm.NFKD
+	default:
+		ok = false
+	}
+	return
 }
 
 type dateCompareConstraint interface {

--- a/marshaling.go
+++ b/marshaling.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"reflect"
 	"strings"
-
-	"golang.org/x/text/unicode/norm"
 )
 
 func (v *Validator) MarshalJSON() ([]byte, error) {
@@ -257,26 +255,6 @@ func (c *ConstraintSet) MarshalJSON() ([]byte, error) {
 func (c *StringPattern) MarshalJSON() ([]byte, error) {
 	j := map[string]interface{}{
 		"Regexp":  c.Regexp.String(),
-		"Message": c.Message,
-		"Stop":    c.Stop,
-	}
-	return json.Marshal(j)
-}
-
-func (c *StringValidUnicodeNormalization) MarshalJSON() ([]byte, error) {
-	strForm := ""
-	switch c.Form {
-	case norm.NFC:
-		strForm = "NFC"
-	case norm.NFD:
-		strForm = "NFD"
-	case norm.NFKC:
-		strForm = "NFKC"
-	case norm.NFKD:
-		strForm = "NFKD"
-	}
-	j := map[string]interface{}{
-		"Form":    strForm,
 		"Message": c.Message,
 		"Stop":    c.Stop,
 	}

--- a/marshaling_test.go
+++ b/marshaling_test.go
@@ -7,7 +7,6 @@ import (
 	"unicode"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/text/unicode/norm"
 )
 
 func TestValidator_MarshalJSON(t *testing.T) {
@@ -445,54 +444,6 @@ func TestConstraint_StringPattern_MarshalJSON(t *testing.T) {
 	require.NotNil(t, obj)
 	require.Equal(t, "test message", obj["Message"])
 	require.Equal(t, "^([A-Z]+)$", obj["Regexp"])
-}
-
-func TestConstraint_StringValidUnicodeNormalization_MarshalJSON(t *testing.T) {
-	c := &StringValidUnicodeNormalization{
-		Form:    norm.NFC,
-		Message: "test message",
-	}
-	b, err := json.Marshal(c)
-	require.Nil(t, err)
-	obj := map[string]interface{}{}
-	err = json.Unmarshal(b, &obj)
-	require.Nil(t, err)
-	require.NotNil(t, obj)
-	require.Equal(t, "test message", obj["Message"])
-	require.Equal(t, "NFC", obj["Form"])
-
-	c = &StringValidUnicodeNormalization{
-		Form: norm.NFD,
-	}
-	b, err = json.Marshal(c)
-	require.Nil(t, err)
-	obj = map[string]interface{}{}
-	err = json.Unmarshal(b, &obj)
-	require.Nil(t, err)
-	require.NotNil(t, obj)
-	require.Equal(t, "NFD", obj["Form"])
-
-	c = &StringValidUnicodeNormalization{
-		Form: norm.NFKC,
-	}
-	b, err = json.Marshal(c)
-	require.Nil(t, err)
-	obj = map[string]interface{}{}
-	err = json.Unmarshal(b, &obj)
-	require.Nil(t, err)
-	require.NotNil(t, obj)
-	require.Equal(t, "NFKC", obj["Form"])
-
-	c = &StringValidUnicodeNormalization{
-		Form: norm.NFKD,
-	}
-	b, err = json.Marshal(c)
-	require.Nil(t, err)
-	obj = map[string]interface{}{}
-	err = json.Unmarshal(b, &obj)
-	require.Nil(t, err)
-	require.NotNil(t, obj)
-	require.Equal(t, "NFKD", obj["Form"])
 }
 
 func TestConstraint_ArrayConditionalConstraint_MarshalJSONFails(t *testing.T) {

--- a/unmarshaling.go
+++ b/unmarshaling.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/text/unicode/norm"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -701,52 +700,6 @@ func (c *StringPattern) UnmarshalJSON(data []byte) error {
 			c.Regexp = *rx
 		} else {
 			return fmt.Errorf(errMsgFieldExpectedType, "Regexp", "regexp string")
-		}
-	}
-	return nil
-}
-
-func (c *StringValidUnicodeNormalization) UnmarshalJSON(data []byte) error {
-	obj := map[string]interface{}{}
-	err := json.Unmarshal(data, &obj)
-	if err != nil {
-		return err
-	}
-	if raw, ok := obj[constraintPtyNameMessage]; ok {
-		if v, ok := raw.(string); ok {
-			c.Message = v
-		} else {
-			return fmt.Errorf(errMsgFieldExpectedType, constraintPtyNameMessage, "string")
-		}
-	}
-	if raw, ok := obj[constraintPtyNameStop]; ok {
-		if v, ok := raw.(bool); ok {
-			c.Stop = v
-		} else {
-			return fmt.Errorf(errMsgFieldExpectedType, constraintPtyNameStop, "bool")
-		}
-	}
-	if raw, ok := obj["Form"]; ok {
-		v, vOk := raw.(string)
-		var form norm.Form
-		if vOk {
-			switch v {
-			case "NFC":
-				form = norm.NFC
-			case "NFD":
-				form = norm.NFD
-			case "NFKC":
-				form = norm.NFKC
-			case "NFKD":
-				form = norm.NFKD
-			default:
-				vOk = false
-			}
-		}
-		if vOk {
-			c.Form = form
-		} else {
-			return fmt.Errorf(errMsgFieldExpectedType, constraintPtyNameStop, "string (\"NFC\", \"NFD\", \"NFKC\" or \"NFKD\")")
 		}
 	}
 	return nil

--- a/unmarshaling_test.go
+++ b/unmarshaling_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/text/unicode/norm"
 	"strings"
 	"testing"
 
@@ -947,82 +946,6 @@ func TestStringPatternUnmarshalJSON(t *testing.T) {
 
 	js = `[]`
 	constraint = &StringPattern{}
-	err = json.Unmarshal([]byte(js), constraint)
-	require.NotNil(t, err)
-}
-
-func TestStringValidUnicodeNormalizationUnmarshalJSON(t *testing.T) {
-	js := `{}`
-	constraint := &StringValidUnicodeNormalization{}
-	err := json.Unmarshal([]byte(js), constraint)
-	require.Nil(t, err)
-
-	js = `{
-		"Form": "NFC",
-		"Message": "foo",
-		"Stop": true
-	}`
-	constraint = &StringValidUnicodeNormalization{}
-	err = json.Unmarshal([]byte(js), constraint)
-	require.Nil(t, err)
-	require.Equal(t, "foo", constraint.Message)
-	require.True(t, constraint.Stop)
-	require.Equal(t, norm.NFC, constraint.Form)
-
-	js = `{
-		"Form": "NFD"
-	}`
-	constraint = &StringValidUnicodeNormalization{}
-	err = json.Unmarshal([]byte(js), constraint)
-	require.Nil(t, err)
-	require.Equal(t, norm.NFD, constraint.Form)
-
-	js = `{
-		"Form": "NFKC"
-	}`
-	constraint = &StringValidUnicodeNormalization{}
-	err = json.Unmarshal([]byte(js), constraint)
-	require.Nil(t, err)
-	require.Equal(t, norm.NFKC, constraint.Form)
-
-	js = `{
-		"Form": "NFKD"
-	}`
-	constraint = &StringValidUnicodeNormalization{}
-	err = json.Unmarshal([]byte(js), constraint)
-	require.Nil(t, err)
-	require.Equal(t, norm.NFKD, constraint.Form)
-
-	js = `{
-		"Form": 123
-	}`
-	constraint = &StringValidUnicodeNormalization{}
-	err = json.Unmarshal([]byte(js), constraint)
-	require.NotNil(t, err)
-
-	js = `{
-		"Form": "XXX"
-	}`
-	constraint = &StringValidUnicodeNormalization{}
-	err = json.Unmarshal([]byte(js), constraint)
-	require.NotNil(t, err)
-
-	js = `[]`
-	constraint = &StringValidUnicodeNormalization{}
-	err = json.Unmarshal([]byte(js), constraint)
-	require.NotNil(t, err)
-
-	js = `{
-		"Message": 123
-	}`
-	constraint = &StringValidUnicodeNormalization{}
-	err = json.Unmarshal([]byte(js), constraint)
-	require.NotNil(t, err)
-
-	js = `{
-		"Stop": 123
-	}`
-	constraint = &StringValidUnicodeNormalization{}
 	err = json.Unmarshal([]byte(js), constraint)
 	require.NotNil(t, err)
 }


### PR DESCRIPTION
Normalisation form in constraints now uses string token. Also added `NormalisationForm` field to `StringExactLength`, `StringLength`, `StringMaxLength` and `StringMinLength` constraints.