### PR TITLE
Fix `NetIsTCP`

### DIFF
--- a/constraints_net.go
+++ b/constraints_net.go
@@ -263,7 +263,7 @@ type NetIsTCP struct {
 
 // Check implements Constraint.Check
 func (c *NetIsTCP) Check(v interface{}, vcx *ValidatorContext) (bool, string) {
-	if str, ok := v.(string); ok && !(c.V4Only && c.V6Only) && str != "" {
+	if str, ok := v.(string); ok && !(c.V4Only && c.V6Only) && str != "" && !strings.HasSuffix(str, ":") {
 		pass := false
 		if ta, err := net.ResolveTCPAddr(useNetwork("tcp", c.V4Only, c.V6Only), str); err == nil {
 			pass = isValidIp(ta.IP, c.V4Only, c.V6Only, c.DisallowPrivate, c.DisallowLoopback)

--- a/constraints_net_test.go
+++ b/constraints_net_test.go
@@ -493,6 +493,9 @@ func TestNetIsTCP(t *testing.T) {
 		"127.0.0.1:65536": {
 			{&NetIsTCP{}, false},
 		},
+		"127.0.0.1:": {
+			{&NetIsTCP{}, false},
+		},
 		"127.0.0.1:80": {
 			{&NetIsTCP{}, true},
 			{&NetIsTCP{DisallowPrivate: true}, true},
@@ -504,6 +507,9 @@ func TestNetIsTCP(t *testing.T) {
 			{&NetIsTCP{V4Only: true, V6Only: true}, false},
 		},
 		"[::1]": {
+			{&NetIsTCP{}, false},
+		},
+		"[::1]:": {
 			{&NetIsTCP{}, false},
 		},
 		"[::1]:80": {


### PR DESCRIPTION
Should not allow trailing `:`